### PR TITLE
feat(dotfiles): 🛠️ work machine setup, kitty overhaul & zellij fix

### DIFF
--- a/.chezmoi.toml.tmpl
+++ b/.chezmoi.toml.tmpl
@@ -1,4 +1,4 @@
 [data]
     name = {{ promptString "Enter your Git display name (e.g. Sourodeep Chatterjee)" | quote }}
     email = {{ promptString "Enter the email address for your Git commits" | quote }}
-    is_work = {{ promptBool "Is this a Work machine? (Uses SSH/Enterprise settings)" false }}
+    is_work = {{ promptBool "Is this a Work machine? (Skips docker-cli/docker-compose in mise)" false }}

--- a/dot_config/atuin/config.toml
+++ b/dot_config/atuin/config.toml
@@ -135,7 +135,7 @@
 
 ## Defaults to true. If enabled, upon hitting enter Atuin will immediately execute the command. Press tab to return to the shell and edit.
 # This applies for new installs. Old installs will keep the old behaviour unless configured otherwise.
-enter_accept = true
+enter_accept = false
 
 ## Defaults to "emacs".  This specifies the keymap on the startup of `atuin
 ## search`.  If this is set to "auto", the startup keymap mode in the Atuin

--- a/dot_config/kitty/kitty.conf
+++ b/dot_config/kitty/kitty.conf
@@ -2,29 +2,97 @@
 # KITTY CONFIGURATION
 # =========================================================================
 
-# --- Scrollback ---
-# Set to a massive number, or use -1 for infinite (though -1 uses memory based on output)
-scrollback_lines 100000
+# --- Font ---
+font_family      JetBrainsMono Nerd Font Mono
+bold_font        auto
+italic_font      auto
+bold_italic_font auto
+font_size        12.0
+adjust_line_height 110%
 
-# Optional: Store scrollback in a dedicated file if you want to save RAM
+# --- Cursor ---
+cursor_shape              beam
+cursor_blink_interval     0.5
+cursor_stop_blinking_after 10.0
+
+# --- Scrollback ---
+scrollback_lines             100000
 scrollback_pager_history_size 1000
 
-# --- Performance ---
-repaint_delay 10
-input_delay 3
-sync_to_monitor yes
+# --- URLs ---
+url_style        curly
+url_color        #8be9fd
+open_url_with    default
+detect_urls      yes
 
-# --- Window Layout ---
-remember_window_size  yes
-initial_window_width  640
-initial_window_height 400
-window_padding_width 4
+# --- Performance ---
+repaint_delay    10
+input_delay      3
+sync_to_monitor  yes
+
+# --- Window ---
+remember_window_size    yes
+initial_window_width    1280
+initial_window_height   800
+window_padding_width    8
 confirm_os_window_close 0
 
-# --- Aesthetics ---
-# background_opacity 0.95
-# dynamic_background_opacity yes
+# --- Background / Transparency ---
+background_opacity        0.92
+dynamic_background_opacity yes
+
+# --- Tab Bar ---
+tab_bar_edge              bottom
+tab_bar_style             powerline
+tab_powerline_style       slanted
+tab_title_template        "{index}: {title}"
+active_tab_font_style     bold
+inactive_tab_font_style   normal
+
+# --- Colors: Dracula ---
+foreground            #f8f8f2
+background            #282a36
+selection_foreground  #ffffff
+selection_background  #44475a
+
+# Normal colors
+color0   #21222c
+color1   #ff5555
+color2   #50fa7b
+color3   #f1fa8c
+color4   #bd93f9
+color5   #ff79c6
+color6   #8be9fd
+color7   #f8f8f2
+
+# Bright colors
+color8   #6272a4
+color9   #ff6e6e
+color10  #69ff94
+color11  #ffffa5
+color12  #d6acff
+color13  #ff92df
+color14  #a4ffff
+color15  #ffffff
+
+# Cursor / selection
+cursor            #f8f8f2
+cursor_text_color #282a36
+
+# Tab bar
+active_tab_foreground   #282a36
+active_tab_background   #bd93f9
+inactive_tab_foreground #f8f8f2
+inactive_tab_background #44475a
+tab_bar_background      #21222c
+
+# --- Startup ---
+startup_session none
 
 # --- Remote Control ---
 allow_remote_control yes
 listen_on unix:/tmp/mykitty
+
+# --- macOS ---
+macos_option_as_alt yes
+macos_quit_when_last_window_closed no

--- a/dot_config/mise/config.toml.tmpl
+++ b/dot_config/mise/config.toml.tmpl
@@ -7,9 +7,10 @@ starship = "latest"
 usage = "latest"
 uv = "latest"
 dart = "latest"
+{{ if not .is_work -}}
 docker-cli = "latest"
 docker-compose = "latest"
-
+{{ end -}}
 
 # CLI tools
 chezmoi = "latest"

--- a/dot_config/zellij/config.kdl
+++ b/dot_config/zellij/config.kdl
@@ -1,0 +1,4 @@
+// Zellij configuration
+// Disable the Kitty keyboard protocol — prevents character doubling
+// when Zellij initializes a new PTY on macOS terminals
+support_kitty_keyboard_protocol false

--- a/dot_gitconfig.tmpl
+++ b/dot_gitconfig.tmpl
@@ -16,7 +16,7 @@
 
 [delta]
     navigate = true  # use n and N to move between diff sections
-    dark = true      # or light = true, or omit for auto-detection
+    dark = true
     syntax-theme = Dracula
     line-numbers = true
     side-by-side = true
@@ -27,18 +27,13 @@
 [diff]
     colorMoved = default
 
-{{ if .is_work -}}
-# --- Work Machine Settings ---
-[url "git@github.com:"]
-    insteadOf = https://github.com/
-{{- else -}}
-# --- Personal Machine Settings ---
+{{ if not .is_work -}}
+# Personal machine: use gh as the Git credential helper
 [credential "https://github.com"]
     helper = !gh auth git-credential
 [credential "https://gist.github.com"]
     helper = !gh auth git-credential
-{{- end }}
-
+{{ end -}}
 [include]
-    # Local overrides (untracked)
+    # Local overrides (untracked) — use this for work-specific settings
     path = ~/.gitconfig_local

--- a/dot_zprofile
+++ b/dot_zprofile
@@ -1,1 +1,6 @@
-eval "$(/opt/homebrew/bin/brew shellenv)"
+# Homebrew (macOS only)
+if [[ -f "/opt/homebrew/bin/brew" ]]; then
+  eval "$(/opt/homebrew/bin/brew shellenv)"
+elif [[ -f "/usr/local/bin/brew" ]]; then
+  eval "$(/usr/local/bin/brew shellenv)"
+fi

--- a/dot_zshrc
+++ b/dot_zshrc
@@ -85,7 +85,11 @@ if [[ $- == *i* ]]; then
   ZINIT_HOME="${XDG_DATA_HOME:-${HOME}/.local/share}/zinit/zinit.git"
   if [ -d "$ZINIT_HOME" ]; then
     source "${ZINIT_HOME}/zinit.zsh"
-    
+
+    # Autosuggestion style: explicit dim color so it never looks like typed text
+    ZSH_AUTOSUGGEST_HIGHLIGHT_STYLE="fg=#6c6c6c,italic"
+    ZSH_AUTOSUGGEST_STRATEGY=(history)   # history only, no completion suggestions
+
     # Plugins in Turbo Mode (Instant startup)
     zinit ice wait"0a" lucid; zinit light zsh-users/zsh-autosuggestions
     zinit ice wait"0b" lucid blockf; zinit light zsh-users/zsh-completions

--- a/install.sh
+++ b/install.sh
@@ -19,15 +19,24 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
   fi
   echo "Homebrew: OK"
 
-  for pkg in git gh; do
-    brew list "$pkg" &>/dev/null || brew install "$pkg"
-  done
+  # gh is managed by mise; only ensure git and duti are present via brew
+  brew list git  &>/dev/null || brew install git
+  brew list duti &>/dev/null || brew install duti
 
   # Nerd Fonts
   brew install --cask font-jetbrains-mono-nerd-font font-meslo-lg-nerd-font 2>/dev/null || true
 
   # tealdeer (no arm64 binary in mise)
   brew list tealdeer &>/dev/null 2>&1 || brew install tealdeer
+
+  # Reset .sh / .zsh file associations away from Kitty so it stops showing
+  # "Waiting to run: ..." every launch. Hand them back to the default editor.
+  if command -v duti &>/dev/null; then
+    duti -s com.apple.TextEdit sh   all 2>/dev/null || true
+    duti -s com.apple.TextEdit zsh  all 2>/dev/null || true
+    duti -s com.apple.TextEdit bash all 2>/dev/null || true
+    echo "File associations: .sh/.zsh/.bash reset to TextEdit"
+  fi
 
 else
   echo "Linux detected"
@@ -47,6 +56,19 @@ else
     sudo apt update && sudo apt install -y git curl zsh gh
   elif command -v pacman &>/dev/null; then
     sudo pacman -S --noconfirm git curl zsh github-cli
+  fi
+
+  # Nerd Fonts (Linux) — install JetBrains Mono + Meslo to ~/.local/share/fonts
+  FONT_DIR="$HOME/.local/share/fonts/NerdFonts"
+  if [[ ! -d "$FONT_DIR" ]]; then
+    echo "Installing Nerd Fonts..."
+    mkdir -p "$FONT_DIR"
+    for nf_font in JetBrainsMono Meslo; do
+      curl -fLo "/tmp/${nf_font}.tar.xz" \
+        "https://github.com/ryanoasis/nerd-fonts/releases/latest/download/${nf_font}.tar.xz"
+      tar -xf "/tmp/${nf_font}.tar.xz" -C "$FONT_DIR"
+    done
+    fc-cache -fv "$FONT_DIR"
   fi
 
 fi
@@ -91,20 +113,26 @@ echo "Checking chezmoi identity..."
 CONFIG_FILE="$HOME/.config/chezmoi/chezmoi.toml"
 TEMPLATE_FILE="$DOTFILES_DIR/.chezmoi.toml.tmpl"
 
-# If the config is missing OR the template is newer than the config, run init
-if [[ ! -f "$CONFIG_FILE" ]] || [[ "$TEMPLATE_FILE" -nt "$CONFIG_FILE" ]]; then
+# Run init if: config is missing, template is newer, OR the [data] section is absent
+# ([data] holds name/email and is required to render dot_gitconfig.tmpl)
+if [[ ! -f "$CONFIG_FILE" ]] || [[ "$TEMPLATE_FILE" -nt "$CONFIG_FILE" ]] || ! grep -q '^\[data\]' "$CONFIG_FILE"; then
   echo "Identity setup: Initializing/Updating configuration..."
-  # This will prompt you for your name/email only when needed
+  echo "  → You will be prompted for: Git name, email, and whether this is a Work machine."
+  echo "    (Work=true skips docker-cli/docker-compose from mise; Rancher already provides them.)"
   chezmoi init
 fi
 
 echo "Applying dotfiles..."
-chezmoi apply
+chezmoi apply --force
 
 # --- 6. Install CLI tools via mise ---
 echo ""
 echo "Installing CLI tools via mise..."
-mise install --yes
+if command -v gh &>/dev/null && gh auth token &>/dev/null 2>&1; then
+  GITHUB_TOKEN=$(gh auth token) mise install --yes
+else
+  mise install --yes
+fi
 
 # --- 7. Deploy IDE keybindings to all VS Code-based IDEs ---
 IDE_SOURCE="$HOME/.config/ide"
@@ -136,7 +164,11 @@ echo "========================================="
 echo ""
 echo "Next steps:"
 echo "  1. Restart your shell (or: exec zsh)"
-echo "  2. Open a new terminal to start Zellij"
+echo "  2. Open a new terminal — zellij will auto-start and attach to 'default' session"
+echo ""
+echo "  • Verify your gitconfig: cat ~/.gitconfig"
+echo "  • Work-specific overrides (proxy, signing key, etc.): edit ~/.gitconfig_local"
+echo "  • gh CLI: run 'gh auth login' if you need GitHub API access (PRs, issues, etc.)"
 echo ""
 echo "Tools managed by mise (run 'mise ls' to see all):"
 mise ls --current 2>/dev/null | awk '{print "  " $1 " " $2}' | head -20


### PR DESCRIPTION
- install.sh: 🔧 drop gh from brew (mise-managed), add duti for .sh file association reset, Linux Nerd Font install, fix chezmoi init to trigger on missing [data], --force apply, GITHUB_TOKEN for mise rate limits
- dot_gitconfig.tmpl: ✨ drop SSH url rewrite; add delta/core/merge/diff visuals; gh credential helper for personal machines only
- mise/config.toml → config.toml.tmpl: 🐳 docker tools conditional on is_work=false (Rancher provides them on work machines)
- zellij/config.kdl: 🐛 disable Kitty keyboard protocol to fix character doubling on macOS BSD PTY
- kitty/kitty.conf: 🎨 full rewrite — Dracula theme, 12pt JetBrains Mono Nerd Font, transparency, powerline tabs, startup_session none
- atuin/config.toml: 🕹️ enter_accept=false for safer history UX
- dot_zshrc: 👻 explicit dim autosuggestion color; history-only strategy
- dot_zprofile: 🐧 OS guard around Homebrew shellenv for Linux safety